### PR TITLE
Retain search parameters during pagination.

### DIFF
--- a/src/App/Action/Publisher/FindPublisherAction.php
+++ b/src/App/Action/Publisher/FindPublisherAction.php
@@ -26,8 +26,6 @@ class FindPublisherAction
 
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next = null)
     {
-        $rows = [];
-        
-        return new HtmlResponse($this->template->render('app::find_publisher', ['rows' => $rows,'request' => $request]));
+        return new HtmlResponse($this->template->render('app::find_publisher'));
     } 
 }

--- a/templates/app/controls.phtml
+++ b/templates/app/controls.phtml
@@ -1,7 +1,9 @@
+<? $extraParams = empty($this->extraParams) ? '' : $this->escapeHtml('&' . $this->extraParams); ?>
+
 <?php if ($this->pageCount): ?>
 <!-- First page link -->
 <?php if (isset($this->previous)): ?>
-  <a href="<?php echo $this->url($this->route, array('page' => $this->first)); ?>">
+  <a href="<?php echo $this->url($this->route) . '?page=' . urlencode($this->first) . $extraParams ?>">
     First
   </a> |
 <?php else: ?>
@@ -10,7 +12,7 @@
  
 <!-- Previous page link -->
 <?php if (isset($this->previous)): ?>
-  <a href="<?php echo $this->url($this->route, array('page' => $this->previous)); ?>">
+  <a href="<?php echo $this->url($this->route) . '?page=' . urlencode($this->previous) . $extraParams ?>">
     &lt; Previous
   </a> |
 <?php else: ?>
@@ -19,7 +21,7 @@
  
 <!-- Next page link -->
 <?php if (isset($this->next)): ?>
-  <a href="<?php echo $this->url($this->route, array('page' => $this->next)); ?>">
+  <a href="<?php echo $this->url($this->route) . '?page=' . urlencode($this->next) . $extraParams ?>">
     Next &gt;
   </a> |
 <?php else: ?>
@@ -28,7 +30,7 @@
  
 <!-- Last page link -->
 <?php if (isset($this->next)): ?>
-  <a href="<?php echo $this->url($this->route, array('page' => $this->last)); ?>">
+  <a href="<?php echo $this->url($this->route) . '?page=' . urlencode($this->last) . $extraParams ?>">
     Last
   </a>
 <?php else: ?>

--- a/templates/app/find_publisher.phtml
+++ b/templates/app/find_publisher.phtml
@@ -1,33 +1,22 @@
-<?php header('Content-Type: text/html; charset=UTF-8'); ?>
 <?php $this->headTitle('Find Publisher'); ?>
-<?php //$this->layout()->instructions = ""; ?>
-<html>
-<head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-</head>
-<body>  
 <div class="col-md-4">
-    <form class="form-horizontal" method="post" action="<?=$this->url('manage_publisher')?><?php echo '?search=true' ?>">
-    
+    <form class="form-horizontal" method="get" action="<?=$this->url('manage_publisher')?>">
         <div class="form-group">
             <label class="col-xs-3 control-label">Name: </label>
             <div class="col-xs-7">
-                <input type="text" class="form-control" name="name_publisher" id="findpublisher-name" />
+                <input type="text" class="form-control" name="name" />
             </div>
         </div>
         <div class="form-group">
             <label class="col-xs-3 control-label">Location: </label>
             <div class="col-xs-7">
-                <input type="text" class="form-control" name="location_publisher" id="findpublisher-location" />
+                <input type="text" class="form-control" name="location" />
             </div>
         </div>
         <div class="form-group">
             <div class="col-sm-offset-3 col-sm-10">
-                <button type="submit" class="btn btn-default" name="search1" value="searched">Search</button>
+                <button type="submit" class="btn btn-default">Search</button>
             </div>
         </div>
     </form>   
 </div>
-<?php //} ?>
-</body>
-</html>

--- a/templates/app/manage_publisher.phtml
+++ b/templates/app/manage_publisher.phtml
@@ -1,11 +1,4 @@
-<?php header('Content-Type: text/html; charset=UTF-8'); ?>
 <?php $this->headTitle('Manage Publisher'); ?>
-<?php //$this->layout()->instructions = ""; ?>
-<html>
-<head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-</head>
-<body>
 <div class="col-md-9">
 <p>
 <?php foreach (range('A', 'Z') as $char) { 
@@ -46,13 +39,15 @@
 		</table>
         <?php if($this->countp > 1) { ?>
         <form method="get" action="page">
-		<?php echo $this->paginationControl($this->rows,
-                                   'Sliding',
-                                   'app::controls', ['route'  => 'manage_publisher']); ?>
-								   
-		</form>	
+            <?=$this->paginationControl($this->rows,
+                'Sliding',
+                'app::controls',
+                [
+                    'route'  => 'manage_publisher',
+                    'extraParams' => $searchParams,
+                ]
+            );?>
+        </form>
         <?php } ?>
         </div>
 </div>
-</body>
-</html>


### PR DESCRIPTION
This pull request allows the results of the "find publisher" action to be paginated correctly.

Notes:

- Instead of using router "attributes" to embed /page/x into the URL, this instead assembles query parameters manually in the controls.phtml template. This may not be the most elegant approach, but it results in cleaner URLs.
- The search is now performed using GET rather than POST so that we can persist the search parameters through pagination. I created an extraParams variable in controls.phtml which can be used to add arbitrary parameters to pagination links. Note that the current workflow in this example is that the controller figures out the search parameters based on the incoming GET parameters and passes those to the action template as the $searchParams variable. The action template in turn passes this to controls.phtml as the $extraParams variable. This may be an unnecessary extra step (we could just set $extraParams directly in the controller), but I wanted to show explicitly how the data is flowing from point to point.
- I've simplified some HTML and code where possible -- removing unnecessary IDs and markup from templates, shortening parameter names, removing unnecessary $this-> prefixes from local variables in controllers, etc.

If you accept this pull request, you'll probably need to make some changes to other actions that use pagination to get everything back in line again. Let me know if you have any questions! 